### PR TITLE
Add RFCs docset

### DIFF
--- a/docsets/RFCs/README.md
+++ b/docsets/RFCs/README.md
@@ -1,0 +1,9 @@
+RFCs Docset
+=======================
+
+This docset contains all published RFCs from the IETF.  It is a mirror of the
+<http://tools.ietf.org/html/> website.
+
+**Author:** [Will Norris](https://willnorris.com/)
+
+**Generating Instructions:** [rfcdash](https://github.com/willnorris/rfcdash#updating-the-docset)

--- a/docsets/RFCs/docset.json
+++ b/docsets/RFCs/docset.json
@@ -1,0 +1,10 @@
+{
+    "name": "RFCs",
+    "version": "1.1",
+    "archive": "RFCs.tgz",
+    "author": {
+        "name": "Will Norris",
+        "link": "https://willnorris.com/"
+    },
+    "aliases": ["rfc"],
+}


### PR DESCRIPTION
This docset is over the 100 mb limit, so I've not included the tarball in this commit.  The current 1.1 version can be obtained from https://github.com/willnorris/rfcdash/releases/download/v1.1/RFCs.tgz

fixes willnorris/rfcdash#1
