### PR TITLE
Repull pin docset

### DIFF
--- a/docsets/Pin/README.md
+++ b/docsets/Pin/README.md
@@ -1,0 +1,16 @@
+Pin Docset
+=======================
+
+## Author
+TheCjw
+
+- Github: [TheCjw](https://github.com/thecjw)
+- Blog: <http://thecjw.0ginr.com>
+
+## Generating Docset
+
+Follow the instructions at <https://github.com/TheCjw/PinDocset>.
+
+## Bugs
+
+Feel free to report bugs on <https://github.com/TheCjw/PinDocset/issues>.

--- a/docsets/Pin/docset.json
+++ b/docsets/Pin/docset.json
@@ -1,0 +1,13 @@
+{
+    "name": "Pin",
+    "version": "2.14",
+    "archive": "Pin_Docset.tgz",
+    "author": {
+        "name": "TheCjw",
+        "link": "http://thecjw.0ginr.com"
+    },
+    "aliases": ["pin",
+                "pintool"
+                ],
+    "specific_versions": []
+}


### PR DESCRIPTION
Fix the issue that there're some entries didn't has the `type` set, 148 entries were updated to `define.` 