### PR TITLE
Update Eigen v3.2.4 docset created by Egor Larionov

### DIFF
--- a/docsets/Eigen/Eigen.tgz.txt
+++ b/docsets/Eigen/Eigen.tgz.txt
@@ -1,4 +1,0 @@
-Archive "Eigen.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2015-01-29 04:21:29 +0000
-SHA1: 4b617e686cacf3f55e8099e381c0a4c382141b10

--- a/docsets/Eigen/README.md
+++ b/docsets/Eigen/README.md
@@ -19,6 +19,7 @@ libraries (usually recognizable by the <Eigen/*Support> header name). Of course
 you have to mind the license of the so-included library when using them.
 
 This docset for Dash is compiled by [Egor Larionov](https://github.com/elrnv)
+This docset for Dash is recompiled by [Zuogong Yue](https://github.com/oracleyue), with LaTeX enabled to fix formula pictures.
 
 # Generate docset
 

--- a/docsets/Eigen/docset.json
+++ b/docsets/Eigen/docset.json
@@ -5,8 +5,8 @@
     "author": {
         "name": "Egor Larionov",
         "link": "https://github.com/elrnv"
-        "name2": "Zuogong Yue",
-        "link2": "https://github.com/oracleyue"
+        "name": "Zuogong Yue",
+        "link": "https://github.com/oracleyue"
     },
     "aliases": ["Linear Algebra", 
                 "Matrices",

--- a/docsets/Eigen/docset.json
+++ b/docsets/Eigen/docset.json
@@ -5,8 +5,6 @@
     "author": {
         "name": "Egor Larionov",
         "link": "https://github.com/elrnv"
-        "name": "Zuogong Yue",
-        "link": "https://github.com/oracleyue"
     },
     "aliases": ["Linear Algebra", 
                 "Matrices",

--- a/docsets/Eigen/docset.json
+++ b/docsets/Eigen/docset.json
@@ -5,6 +5,8 @@
     "author": {
         "name": "Egor Larionov",
         "link": "https://github.com/elrnv"
+        "name2": "Zuogong Yue",
+        "link2": "https://github.com/oracleyue"
     },
     "aliases": ["Linear Algebra", 
                 "Matrices",


### PR DESCRIPTION
It comes from the docset created by Egor Larionov. The docset is recompiled to fix the formula picture bugs in the version compiled by Egor Larionov, by enabling LaTeX in compilation.
Nothing else has been changed, except adding my information in the Readme.md. All rights are still reserved by the original author Egor Larionov. Please also let Egor Larionov know this update. 

Thanks!