### PR TITLE
Better Kotlin index

### DIFF
--- a/docsets/Kotlin/docset.json
+++ b/docsets/Kotlin/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Kotlin",
-    "version": "0.12.613",
+    "version": "0.12.613/not-just-guides",
     "archive": "Kotlin.tgz",
     "author": {
         "name": "Marcel Jackwerth",


### PR DESCRIPTION
The current Kotlin index only has `Guides` with weird names like `stdlib / kotlin.Boolean`. This PR fixes the names and sets the correct types.

Sorry for bugging you again today. :no_mouth: 