### PR TITLE
updated Kotlin docset to 1.0.0-beta-1103

### DIFF
--- a/docsets/Kotlin/README.md
+++ b/docsets/Kotlin/README.md
@@ -14,5 +14,4 @@ Where to get the docs:
 
 Known Bugs:
 
-- Doesn't include API documentation yet (they will [change them soon](http://kotlinlang.org/docs/api/index.html)).
 - Some pages of the original Kotlin documentation are missing source code. Once they get this fixed we'll update the docset.

--- a/docsets/Kotlin/docset.json
+++ b/docsets/Kotlin/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Kotlin",
-    "version": "0.12.613/not-just-guides",
+    "version": "1.0.0-beta-1103",
     "archive": "Kotlin.tgz",
     "author": {
         "name": "Marcel Jackwerth",


### PR DESCRIPTION
Updated very outdated Kotlin docset (they changed a lot for 1.0-beta). Does the following cause an issue?

    "version": "1.0.0-beta-1103"

Or should I set it to `1.0.0/beta-1103`, which would be a little bit confusing I guess.