### PR TITLE
update RFCs docset to v1.3

### DIFF
--- a/docsets/RFCs/docset.json
+++ b/docsets/RFCs/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "RFCs",
-    "version": "1.2",
+    "version": "1.3",
     "archive": "RFCs.tgz",
     "author": {
         "name": "Will Norris",


### PR DESCRIPTION
This docset is over the 100 mb limit, so I've not included the tarball in this commit. The current 1.3 version can be obtained from https://github.com/willnorris/rfcdash/releases/download/v1.3/RFCs.tgz