### PR TITLE
Update from version 0.17.1 to 0.18.0

### DIFF
--- a/docsets/Scikit/docset.json
+++ b/docsets/Scikit/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Scikit-learn",
-    "version": "0.17.1",
+    "version": "0.18.0",
     "archive": "Scikit-learn.tgz",
     "author": {
         "name": "Aziz Alto",


### PR DESCRIPTION
Update to the new version of scikit-learn (v.0.18).

__P.S.__ Line 25 of the file `scikit-to-dash.py` needs to be changed from `urllib.urlretieve` to `urllib.request.urlretrieve` (I am waiting for my pull request to be accepted by Aziz Alto).