### PR TITLE
Update LLVM Core

### DIFF
--- a/docsets/LLVM/README.md
+++ b/docsets/LLVM/README.md
@@ -1,4 +1,15 @@
-LLVM Dash Docset
+Original LLVM-Dash was last updated on 9 Sep 2015, more than two years ago.
+Unlike original version , this one was built according to the official guide with some modifications.
+See <http://mayuyu.io/llvm/2017/04/06/BuildingLLVMDoc.html>
+
+
+Below was the original README
+
+
+Naville Zhang
+
+
+## LLVM Dash Docset
 =======================
 
 - __Docset Description__:

--- a/docsets/LLVM/docset.json
+++ b/docsets/LLVM/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "LLVM",
-    "version": "3.7",
-    "archive": "LLVM.tgz",
+    "version": "5.0SVN301109",
+    "archive": "LLVM.7z",
     "author": {
-        "name": "Aziz Alto",
-        "link": "https://github.com/iamaziz"
+        "name": "Naville",
+        "link": "https://github.com/Naville"
     },
     "aliases": ["Compiler Infrastrcture",
                 "Compilers"


### PR DESCRIPTION
The zip is  128.3MB when compressed using 7z, which I found reasonable compared to other 700mb+ LLVM PRs 
Please refer to https://mega.nz/#!DhNSDbCC!26ajVUdxkj3EniYCqSvaZIHZwQLpy_4MOTIOYQ44jA8