### PR TITLE
Updated Terraform Docset to v0.10.6

### DIFF
--- a/docsets/Terraform/README.deprecated.md
+++ b/docsets/Terraform/README.deprecated.md
@@ -1,0 +1,17 @@
+Terraform Docset
+=======================
+
+https://terraform.io/docs/
+
+Contriubuted by [f440](https://github.com/f440)
+
+## Building the docsets
+
+    git clone https://github.com/f440/terraform.git
+    cd terraform/website
+    git checkout docset
+    rake
+
+## Old version (< 0.6.0)
+
+ref. [README.old.md](README.old.md)

--- a/docsets/Terraform/README.md
+++ b/docsets/Terraform/README.md
@@ -3,14 +3,19 @@ Terraform Docset
 
 https://terraform.io/docs/
 
-Contriubuted by [f440](https://github.com/f440)
+Contriubuted by [rolandjohann](https://github.com/rolandjohann/terraform-dash-doc-generator.git)
 
 ## Building the docsets
 
-    git clone https://github.com/f440/terraform.git
-    cd terraform/website
-    git checkout docset
-    rake
+```sh
+git clone https://github.com/rolandjohann/terraform-dash-doc-generator.git
+./build_until_0.9.sh # to build all docsets until v0.9.11
+./build_current_from_0.10.sh <version> # to build current state of https://github.com/hashicorp/terraform-website.git and move to build/<version>
+```
+
+## Old version (< 0.10.0)
+
+ref. [README.deprecated.md](README.deprecated.md)
 
 ## Old version (< 0.6.0)
 

--- a/docsets/Terraform/README.md
+++ b/docsets/Terraform/README.md
@@ -9,6 +9,7 @@ Contriubuted by [rolandjohann](https://github.com/rolandjohann/terraform-dash-do
 
 ```sh
 git clone https://github.com/rolandjohann/terraform-dash-doc-generator.git
+cd terraform-dash-doc-generator
 ./build_until_0.9.sh # to build all docsets until v0.9.11
 ./build_current_from_0.10.sh <version> # to build current state of https://github.com/hashicorp/terraform-website.git and move to build/<version>
 ```


### PR DESCRIPTION
Terraform doc management has been changed since v0.10.0 and required several changes to use the existing code and generate the dash docset.

In addition, the generator script contains a fix for separating terraform data and resources at the SQlite index. This requires that the old docs should be regenerated - is it possible to just replace the old docsets?