### PR TITLE
Update Crystal docset to 0.23.1

### DIFF
--- a/docsets/Crystal/docset.json
+++ b/docsets/Crystal/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Crystal",
-    "version": "0.22.0",
+    "version": "0.23.1",
     "archive": "Crystal.tgz",
     "author": {
         "name": "Sijawusz Pur Rahnama",


### PR DESCRIPTION
This updates the Crystal Docset to 0.23.1 and removes the sidebar from the API docs using CSS.

The sidebar in the API docs did show a navigation and search for the types which duplicated functionality already provided equally well by Dash itself and took up screen space.

The following CSS changes where made to hide the types list in `css/style.css`:

```css
#types-list { display: none; }
#main-content { left: 0; }
```

I have left the menu for the Crystal User Guide, because it can be hidden by the user and provides the necessary hierarchy that is lacking from the generated TOC.