### PR TITLE
Clarification about docset archive locations (Wagtail)

### DIFF
--- a/docsets/Wagtail/README.md
+++ b/docsets/Wagtail/README.md
@@ -27,5 +27,12 @@ __How to generate the docset:__
 
         tar --exclude='.DS_Store' -cvzf Wagtail.tgz Wagtail.docset
 
+- Copy the archived docset `Wagtail.tgz` to two locations (keep the filename the same):
+    1. `specific_versions` folder within a sub-folder with the version name
+    2. main `docsets/Wagtail` folder
+
 - Update the version in `docset.json`
+
+__Icon:__
+
 - Icon from http://docs.wagtail.io/en/latest/_static/logo.png


### PR DESCRIPTION
Also moved the icon note to its own heading as it is not really part of the normal instructions