### PR TITLE
Update and improve scikit-learn docs

### DIFF
--- a/docsets/Scikit/README.md
+++ b/docsets/Scikit/README.md
@@ -5,4 +5,5 @@ scikit-learn documentation
   * Josh Devlin - jaypeedevlin on twitter and github
   * Joel Nothman - jnothman on github
 * Complete instructions on how to generate the docset:
-  * `./build.sh` with Python 3.5+ on path
+  * Requirements: Python 3.5+ on path; `optipng`
+  * Run: `./build.sh`

--- a/docsets/Scikit/README.md
+++ b/docsets/Scikit/README.md
@@ -1,12 +1,8 @@
-scikit-learn v0.18.0 documentation
-=======================
+scikit-learn documentation
+==========================
 
 * Who are you:
   * Josh Devlin - jaypeedevlin on twitter and github
-* Complete instructions on how to generate the docset, including:
-  * Pull Repo from https://github.com/scikit-learn/scikit-learn
-  * `cd doc && make html`
-  * `cd foobar && doc2dash -a ./`
-* Anything else you think is relevant
-  * This version was only released weeks ago, not sure if it's worthwhile adding previous versions as well.
-  * Let me know if any changes are needed or if there's anything else I can do to help.
+  * Joel Nothman - jnothman on github
+* Complete instructions on how to generate the docset:
+  * `./build.sh` with Python 3.5+ on path

--- a/docsets/Scikit/build.sh
+++ b/docsets/Scikit/build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+if [ $# -gt 1 ]
+then
+	echo Usage $0 [GIT-TAG] >&2
+	exit 1
+fi
+
+tag=$1
+
+if [ -z "$tag" ]
+then
+	tag=$(curl 'https://api.github.com/repos/scikit-learn/scikit-learn/releases?per_page=1' | python -c 'import json, sys; print(json.load(sys.stdin)[0]["tag_name"])')
+fi
+
+originaldir=$(pwd)
+workdir=$(mktemp -d -t sklearn2dash)
+trap "{ rm -rf $workdir; }" EXIT
+
+# setup virtual environment
+virtualenv $workdir/venv
+source $workdir/venv/bin/activate
+cp userguide.py $workdir
+
+# build docs
+# XXX: alternatively we could just download from scikit-learn.github.io assuming versions are matched
+cd $workdir
+# TODO: perhaps scikit-learn should provide an environment.yml and this script should use conda-env...
+pip install numpy scipy cython nose coverage matplotlib sphinx pillow sphinx-gallery numpydoc
+pip install doc2dash scikit-learn==$tag
+git clone --depth 1 --branch $tag https://github.com/scikit-learn/scikit-learn
+cd scikit-learn/doc
+make html
+cd $workdir
+
+# convert to dash
+doc2dash --index-page documentation.html --parser userguide.ScikitLearnDocs -n scikit-learn scikit-learn/doc/_build/html/stable
+tar --exclude='.DS_Store' -czvf scikit-learn.tgz scikit-learn.docset
+
+# update Dash-User-Contributions
+cd $originaldir
+cp $workdir/scikit-learn.tgz .
+# update docset.json
+sed -i bak 's/"version": ".*,/"version": "'$tag'",/' docset.json
+git add docset.json scikit-learn.tgz

--- a/docsets/Scikit/build.sh
+++ b/docsets/Scikit/build.sh
@@ -15,6 +15,10 @@ then
 	tag=$(curl 'https://api.github.com/repos/scikit-learn/scikit-learn/releases?per_page=1' | python -c 'import json, sys; print(json.load(sys.stdin)[0]["tag_name"])')
 fi
 
+# check prerequisites
+python --version 2>&1 | grep -q 'Python 3' || (echo 'Require Python 3' >&2; exit 2)
+which optipng || (echo 'Require optipng' >&2; exit 2)
+
 originaldir=$(pwd)
 workdir=$(mktemp -d -t sklearn2dash)
 trap "{ rm -rf $workdir; }" EXIT
@@ -32,7 +36,7 @@ pip install numpy scipy cython nose coverage matplotlib sphinx pillow sphinx-gal
 pip install doc2dash scikit-learn==$tag
 git clone --depth 1 --branch $tag https://github.com/scikit-learn/scikit-learn
 cd scikit-learn/doc
-make html
+make html optipng
 cd $workdir
 
 # convert to dash

--- a/docsets/Scikit/docset.json
+++ b/docsets/Scikit/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "scikit-learn",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "archive": "scikit-learn.tgz",
     "author": {
-        "name": "Aziz Alto, Josh Devlin, Christian Stade-Schuldt",
-        "link": "https://github.com/iamaziz, https://github.com/jaypeedevlin and https://github.com/tafkas"
+        "name": "Aziz Alto, Josh Devlin, Christian Stade-Schuldt, Joel Nothman",
+        "link": "https://github.com/iamaziz, https://github.com/jaypeedevlin, https://github.com/tafkas, https://github.com/jnothman"
     },
-    "aliases": [],
+    "aliases": []
 }

--- a/docsets/Scikit/userguide.py
+++ b/docsets/Scikit/userguide.py
@@ -1,0 +1,30 @@
+from doc2dash.parsers.intersphinx import (InterSphinxParser,
+                                          inv_entry_to_path,
+                                          ParserEntry)
+
+
+class ScikitLearnDocs(InterSphinxParser):
+    def convert_type(self, inv_type):
+        if inv_type == 'std:doc':  # sphinx type
+            return 'Guide'  # Dash type
+        if inv_type.endswith(':attribute'):
+            # Hide attributes in scikit-learn, at least for now
+            return
+        return super(ScikitLearnDocs, self).convert_type(inv_type)
+
+    def create_entry(self, dash_type, key, inv_entry):
+        if dash_type == 'Guide':
+            path_str = inv_entry_to_path(inv_entry)
+            name = inv_entry[3]
+            if name == '<no title>':
+                return
+            if inv_entry[2].startswith('modules/generated/'):
+                return
+            if inv_entry[2].startswith('auto_examples/'):
+                name = 'Example: ' + name
+            if inv_entry[2].startswith('tutorial/'):
+                name = 'Tutorial: ' + name
+            return ParserEntry(name=name, type=dash_type,
+                               path=path_str)
+        return super(ScikitLearnDocs,
+                     self).create_entry(dash_type, key, inv_entry)


### PR DESCRIPTION
* Update from 0.19.0 to 0.19.1
* Use recent doc2dash custom parser feature to enhance docs
    * add user guides to TOC
    * prefix some user guide titles to indicate structure and subtypes
    * remove attributes from TOC as not consistently exported by
      numpydoc/doc2dash at present
* Add index page
* Add a build script to automatically acquire and build docs for a given version tag, and package them in preparation for committing to Dash-User-Contributions