### PR TITLE
Update docset.json

### DIFF
--- a/docsets/Terraform/docset.json
+++ b/docsets/Terraform/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Terraform",
-    "version": "0.10.8",
+    "version": "0.11.1",
     "archive": "Terraform.tgz",
     "author": {
         "name": "rolandjohann",


### PR DESCRIPTION
Update "version" to latest: 0.11.1

Unless there is a reason to have the default version not be the latest?