### PR TITLE
Update RFCs docset to v1.5.0

### DIFF
--- a/docsets/RFCs/README.md
+++ b/docsets/RFCs/README.md
@@ -4,6 +4,6 @@ RFCs Docset
 This docset contains all published RFCs from the IETF.  It is a mirror of the
 <http://tools.ietf.org/html/> website.
 
-**Author:** [Will Norris](https://willnorris.com/)
+**Author:** [Will Norris](https://willnorris.com/), [Simone Carletti](https://simonecarletti.com/)
 
-**Generating Instructions:** [rfcdash](https://github.com/willnorris/rfcdash#updating-the-docset)
+**Generating Instructions:** [rfcdash](https://github.com/weppos/rfcdash#updating-the-docset)

--- a/docsets/RFCs/docset.json
+++ b/docsets/RFCs/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "RFCs",
-    "version": "1.2",
+    "version": "1.5",
     "archive": "RFCs.tgz",
     "author": {
-        "name": "Will Norris",
-        "link": "https://willnorris.com/"
+        "name": "Simone Carletti",
+        "link": "https://simonecarletti.com/"
     },
     "aliases": ["rfc"],
 }


### PR DESCRIPTION
I updated the RFC docset, and it passed the validation using the tool mentioned at #1051.

You can download the archive at
https://cl.ly/0s1k080e1N0K/download/RFCs.docset-v1.5.0.tgz

/cc @willnorris 