### PR TITLE
ENH: Adds seaborn 0.9.0

### DIFF
--- a/docsets/Seaborn/README.md
+++ b/docsets/Seaborn/README.md
@@ -3,11 +3,11 @@ Seaborn Dash Docset
 
 ### Docset Description:
    - [Seaborn](http://web.stanford.edu/~mwaskom/software/seaborn/) Seaborn is a Python visualization library based on matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
- 
-### Author:
-   - [Peixian Wang](https://github.com/peixian)
-   - [Aziz Alto](https://github.com/iamaziz) (Previous Version)
 
-### Docset Generation: 
+### Author:
+   - [Thomas Fan](https://github.com/thomasjpfan)
+   - [Peixian Wang](https://github.com/peixian) (Previous Version)
+
+### Docset Generation:
   - Inital HTML: https://github.com/mwaskom/seaborn/tree/master/doc
-  - Docset Generation Tool: https://github.com/peixian/seaborn-dash
+  - Docset Generation Tool: https://github.com/thomasjpfan/seaborn-docset

--- a/docsets/Seaborn/Seaborn.tgz.txt
+++ b/docsets/Seaborn/Seaborn.tgz.txt
@@ -1,4 +1,0 @@
-Archive "Seaborn.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2017-08-24 10:21:05 +0000
-SHA1: 1bc799e4ff6fb3491c177b667a11775bf5b5c81a

--- a/docsets/Seaborn/docset.json
+++ b/docsets/Seaborn/docset.json
@@ -1,15 +1,15 @@
 {
     "name": "Seaborn",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "archive": "Seaborn.tgz",
     "author": {
-        "name": "Peixian Wang and Christian Stade-Schuldt",
-        "link": "https://github.com/peixian and https://github.com/tafkas"
+        "name": "Thomas Fan and Peixian Wang",
+        "link": "https://github.com/thomasjpfan and https://github.com/peixian"
     },
     "aliases": [
         "Seaborn Python",
-	      "Python visualization library",
-	      "matplotlib based",
+        "Python visualization library",
+        "matplotlib based",
         "sns"
-        ]
+    ]
 }


### PR DESCRIPTION
This PR builds on the work done in https://github.com/Kapeli/Dash-User-Contributions/pull/1060. Seaborn's tutorial and gallery are added as Dash `Guides` and `Samples`, respectively. 