### PR TITLE
Updating boto3 Docset to v1.7.78

### DIFF
--- a/docsets/Boto3/README.md
+++ b/docsets/Boto3/README.md
@@ -3,7 +3,7 @@ Boto3 Docset
 Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for Python, which allows Python developers to write software that makes use of services like Amazon S3 and Amazon EC2.
 http://boto3.readthedocs.io/en/latest/
 
-* Boto3 Version: 1.7.66
+* Boto3 Version: 1.7.78
 * Dash Docset: Updated by Randall Kahler
 * Twitter: @angrychimp
 * Github: https://github.com/angrychimp

--- a/docsets/Boto3/boto3.tgz.txt
+++ b/docsets/Boto3/boto3.tgz.txt
@@ -1,6 +1,0 @@
-Archive "boto3.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2018-08-01 21:51:36 +0000
-SHA1: a8746e1df4ae93b31ea9dade57fcac7b1b58547e
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/Boto3/docset.json
+++ b/docsets/Boto3/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "boto3",
-    "version": "1.7.66",
+    "version": "1.7.78",
     "archive": "boto3.tgz",
     "author": {
         "name": "Randall Kahler",


### PR DESCRIPTION
For a list of changes included in this docset update please see the boto3 changelog:
https://github.com/boto/boto3/blob/develop/CHANGELOG.rst