### PR TITLE
Kotlin

### DIFF
--- a/docsets/kotlin/README.md
+++ b/docsets/kotlin/README.md
@@ -1,0 +1,11 @@
+Kotlin Docset
+=======================
+
+> Who are you
+Kevin Cianfarini, kevincianfarini on Github/GitLab
+
+> Complete Instructions on how to generate the docset
+
+* Clone my docset generation script repo from [here](https://github.com/kevincianfarini/kotlin2docset)
+* Follow the README instructions there. 
+

--- a/docsets/kotlin/docset.json
+++ b/docsets/kotlin/docset.json
@@ -1,0 +1,9 @@
+{
+    "name": "Kotlin",
+    "version": "1.3.1",
+    "archive": "kotlin.tgz",
+    "author": {
+        "name": "Kevin Cianfarini"
+    },
+    "aliases": []
+}


### PR DESCRIPTION
I've noticed that the Kotlin user submitted docset is...lacking. Rather than indexing the standard library and language features, they've attempted to index the code samples they provide and their guides. It's also stuck at Kotlin 1.1; Kotlin 1.3 is stable at the date of this PR. Rather than trying to salvage their repo and make a PR or fork from there, I decided to make my own because it's in essence a totally different goal we're achieving. 

This is a pull request for indexing the Kotlin 1.3 standard library. I've made an attempt using BeautifulSoup4 and mirroring their stdlib docs using wget. If you'd like to take a look at the generation script, please go [here](https://github.com/kevincianfarini/kotlin2docset). 

If there's anything I should fix, please let me know. It would also be very useful to have someone test with Dash, because I'm only able to test using Zeal on a Linux machine. 

Let me know what you think! :)