### PR TITLE
Enable JavaScript on SuperCollider docSet

### DIFF
--- a/docsets/SuperCollider/versions/3.10/supercollider.tgz.txt
+++ b/docsets/SuperCollider/versions/3.10/supercollider.tgz.txt
@@ -1,6 +1,0 @@
-Archive "supercollider.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2018-11-29 20:17:24 +0000
-SHA1: a4149dd66bb8a3cbaf802463e42dc2d76e1fe46d
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.


### PR DESCRIPTION
I missed that in this version, the examples in the documentation are loaded by a local JavaScript file. This is the same version of the docset, just with JavaScript enabled.

Let me know if you'd also like me to update the plist that points to the version. I wasn't sure what the protocol was here. Thanks!