### PR TITLE
Update PeopleTools 8.57 to revision 2

### DIFF
--- a/docsets/PeopleTools/docset.json
+++ b/docsets/PeopleTools/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "PeopleTools",
-    "version": "8.57",
+    "version": "8.57/r2",
     "archive": "PeopleTools.tgz",
     "author": {
         "name": "Jonathan Rehm",


### PR DESCRIPTION
I am on Windows and use Velocity there. I tested the docset and I believe it's working correctly, but I cannot test the installation part. In the past the archive had problems on *nix machines, so I built it using WSL (Windows Sub-system for Linux). Hopefully it works correctly. 🤞 