### PR TITLE
Updating Boto3 docset to version 1.9.149

### DIFF
--- a/docsets/Boto3/README.md
+++ b/docsets/Boto3/README.md
@@ -3,7 +3,7 @@ Boto3 Docset
 Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for Python, which allows Python developers to write software that makes use of services like Amazon S3 and Amazon EC2.
 http://boto3.readthedocs.io/en/latest/
 
-* Boto3 Version: 1.9.106
+* Boto3 Version: 1.9.149
 * Dash Docset: Updated by Randall Kahler
 * Twitter: @angrychimp
 * Github: https://github.com/angrychimp

--- a/docsets/Boto3/boto3.tgz.txt
+++ b/docsets/Boto3/boto3.tgz.txt
@@ -1,6 +1,0 @@
-Archive "boto3.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2019-03-04 23:25:39 +0000
-SHA1: 6795882842bc8587074356b97b2a112a2f4da6a0
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/Boto3/docset.json
+++ b/docsets/Boto3/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "boto3",
-    "version": "1.9.106",
+    "version": "1.9.149",
     "archive": "boto3.tgz",
     "author": {
         "name": "Randall Kahler",


### PR DESCRIPTION
- Fixed an issue where some files within the docset weren't be updated properly
- Fixed some display issues related to some weirdness between sphinx versions required for building docs and converting to Dash format