### PR TITLE
Update RFC docset to v1.6.1

### DIFF
--- a/docsets/RFCs/docset.json
+++ b/docsets/RFCs/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "RFCs",
-    "version": "1.6",
+    "version": "1.6.1",
     "archive": "RFCs.tgz",
     "author": {
         "name": "Simone Carletti",


### PR DESCRIPTION
I updated the RFC docset, and it passed the validation:

```
➜  Dash-User-Contributions git:(rfc-160) ✗ wget https://kapeli.com/feeds/zzz/docsetcontrib.tgz && tar -xzf docsetcontrib.tgz && ./docsetcontrib --verify
--2019-08-24 22:52:29--  https://kapeli.com/feeds/zzz/docsetcontrib.tgz
Resolving kapeli.com (kapeli.com)... 23.92.22.81
Connecting to kapeli.com (kapeli.com)|23.92.22.81|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 141080 (138K) [application/x-tar]
Saving to: 'docsetcontrib.tgz'

docsetcontrib.tgz                                100%[==========================================================================================================>] 137.77K   417KB/s    in 0.3s

2019-08-24 22:52:30 (417 KB/s) - 'docsetcontrib.tgz' saved [141080/141080]

Checking RFCs/RFCs.tgz...
```

You can download the archive at
https://storage.googleapis.com/rfcdash/RFCs.docset-v1.6.1.tgz
