### PR TITLE
Update date-fns docset to 2.8.1

### DIFF
--- a/docsets/date-fns/docset.json
+++ b/docsets/date-fns/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "date-fns",
-    "version": "1.29.0",
+    "version": "2.8.1",
     "archive": "date-fns.tgz",
     "author": {
         "name": "Ian Sinnott",


### PR DESCRIPTION
Updates date-fns to 2.8.1.

Also filed a PR on iansinnott/date-fns-dash-docset#1 but original author isn't replying, so thought I'd just upstream this myself now.