### PR TITLE
Update Qt for Python (PySide2) to 5.14.2.1

### DIFF
--- a/docsets/Qt_for_Python/README.md
+++ b/docsets/Qt_for_Python/README.md
@@ -8,5 +8,5 @@
 
 ## License
 
-- [Qt for Python](https://doc.qt.io/qtforpython/index.html) use [GNU Free Documentation License version 1.3](https://www.gnu.org/licenses/fdl-1.3.en.html).
-- [Qt for Python (PySide2) to Dash Docset](https://github.com/acbetter/qt-for-python-to-dash-docset) use [Apache License Version 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+- [Qt for Python Documentation](https://doc.qt.io/qtforpython/index.html) use [GNU Free Documentation License version 1.3](https://www.gnu.org/licenses/fdl-1.3.en.html)
+- [Qt for Python (PySide2) to Dash Docset](https://github.com/acbetter/qt-for-python-to-dash-docset) use [Apache License Version 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)

--- a/docsets/Qt_for_Python/docset.json
+++ b/docsets/Qt_for_Python/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "Qt for Python",
-  "version": "5.13.0",
+  "version": "5.14.2.1",
   "archive": "Qt_for_Python.tgz",
   "author": {
     "name": "AC Better",
@@ -11,6 +11,10 @@
     {
       "version": "5.13.0",
       "archive": "versions/5.13.0/Qt_for_Python.tgz"
+    },
+    {
+      "version": "5.14.2.1",
+      "archive": "versions/5.14.2.1/Qt_for_Python.tgz"
     }
   ]
 }


### PR DESCRIPTION
fixes and changes for 5.14 doc style and update doc version
more info see [https://github.com/acbetter/qt-for-python-to-dash-docset/pull/1](https://github.com/acbetter/qt-for-python-to-dash-docset/pull/1)