### PR TITLE
juce-6.0.0 final

### DIFF
--- a/docsets/JUCE/JUCE.tgz.txt
+++ b/docsets/JUCE/JUCE.tgz.txt
@@ -1,6 +1,0 @@
-Archive "JUCE.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-05-21 12:38:40 +0000
-SHA1: fc3c75e66743f367964de4bdf244c582b188b658
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/JUCE/docset.json
+++ b/docsets/JUCE/docset.json
@@ -1,7 +1,7 @@
 {
     "name": "JUCE",
-    "version": "5.4.7",
-    "archive": "JUCE.tgz",
+    "version": "6.0.0",
+    "archive": "versions/6.0.0/JUCE.tgz",
     "author": {
         "name": "modosc",
         "link": "https://github.com/modosc"
@@ -12,8 +12,8 @@
     ],
     "specific_versions": [
         {
-            "version": "6.0.0/preview2",
-            "archive": "versions/6.0.0-preview2/JUCE.tgz"
+            "version": "6.0.0",
+            "archive": "versions/6.0.0/JUCE.tgz"
         },
         {
             "version": "5.4.7",

--- a/docsets/JUCE/versions/6.0.0-preview2/JUCE.tgz.txt
+++ b/docsets/JUCE/versions/6.0.0-preview2/JUCE.tgz.txt
@@ -1,6 +1,0 @@
-Archive "JUCE.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-06-29 17:14:23 +0000
-SHA1: 19b85322c2024a980d314ef7d92a91dd7ac6b1df
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.


### PR DESCRIPTION
juce 6.0.0 released - making this the default version now but still supporting the last 5.x release as well. 