### PR TITLE
update PEPs

### DIFF
--- a/docsets/PEPs/docset.json
+++ b/docsets/PEPs/docset.json
@@ -1,11 +1,11 @@
 {
     "name": "Python Enhancement Proposals",
-    "version": "1.0",
+    "version": "2020.07",
     "archive": "PEPs.tgz",
     "author": {
         "name": "QuantumGhost",
         "link": "https://github.com/quantumghost"
     },
-    "aliases": ["PEP", 
+    "aliases": ["PEP",
                 "PEPs"],
 }


### PR DESCRIPTION
Not sure if the version "2020.07" is allowed.
PEPs does not have "version number" AFAIK. It's updated continuously so it seems better to use date.