### PR TITLE
Updated for ns-3.32

### DIFF
--- a/docsets/ns-3/Info.plist
+++ b/docsets/ns-3/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleIdentifier</key><string>org.nsnam.ns3</string>
 		<key>DocSetPlatformFamily</key><string>ns3</string>
 		<key>dashIndexFilePath</key><string>modules.html</string>
-		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.29/doxygen/index.html</string>
+		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.32/doxygen/index.html</string>
 		<key>isJavaScriptEnabled</key><true/>
 	</dict>
 </plist>

--- a/docsets/ns-3/docset.json
+++ b/docsets/ns-3/docset.json
@@ -1,6 +1,6 @@
 {
 	"name": "ns-3",
-	"version": "3.30",
+	"version": "3.32",
 	"archive": "ns-3.tgz",
 	"author": {
 		"name": "Elias Rohrer",
@@ -9,6 +9,14 @@
 	"aliases": [ "ns3" ],
 
 	"specific_versions": [
+		{ 
+			"version": "3.31",
+			"archive": "versions/3.31/ns-3.tgz"
+		},	
+		{ 
+			"version": "3.30",
+			"archive": "versions/3.30/ns-3.tgz"
+		},	
 		{ 
 			"version": "3.29",
 			"archive": "versions/3.29/ns-3.tgz"


### PR DESCRIPTION
As discussed, this pull request updates the supplementary files for the ns-3.32 docset.

The docset itself you can find under:

https://www.dropbox.com/s/3lmms0ofnbemu2c/ns-3.tgz?dl=0

It would be great if you could process the prior pull request https://github.com/Kapeli/Dash-User-Contributions/pull/3062 first, and put the `ns-3.tgz` provided there under `versions/3.31/`.

Thank you!