### PR TITLE
New QGIS 3.16 docset

### DIFF
--- a/docsets/QGIS/README.md
+++ b/docsets/QGIS/README.md
@@ -38,7 +38,7 @@ Then, in *doc/api/html/Info.plist* remove *CFBundleVersion* (key and string valu
 <true/>
 ```
 
-Then generate docset (doxytag2zealdb can be installed with pip)
+Then generate docset (doxytag2zealdb can be installed with pip, but be aware that you may have to apply this [patch](https://github.com/vedvyas/doxytag2zealdb/pull/2)). 
 ```shell
 # First command fail on docsetutil missing, nevermind!
 cd doc/api/html && make
@@ -53,5 +53,5 @@ If you want to propose a PR to update this documentation, just zip it, share it 
 To create the tar archive
 
 ```shell
-cd doc/api/html && tar cvzf QGIS.tgz --exclude='.DS_Store' doc/api/html/QGIS_3.docset
+cd doc/api/html && tar cvzf QGIS.tgz --exclude='.DS_Store' QGIS_3.docset
 ```

--- a/docsets/QGIS/README.md
+++ b/docsets/QGIS/README.md
@@ -16,7 +16,7 @@ Then edit Doxyfile template file *cmake_templates/Doxyfile.in* and modify these 
 ```
 GENERATE_DOCSET        = YES
 DOCSET_FEEDNAME        = "QGIS"
-DOCSET_BUNDLE_ID       = QGIS_3.docset
+DOCSET_BUNDLE_ID       = QGIS_3
 DOCSET_PUBLISHER_ID    = com.QGIS
 DOCSET_PUBLISHER_NAME  = QGIS
 DISABLE_INDEX          = YES
@@ -28,7 +28,8 @@ Build it
 ```shell
 mkdir build
 cd build
-cmake ../ -DWITH_APIDOC=TRUE -DWITH_3D=TRUE
+cmake ../ -DWITH_APIDOC=TRUE -DWITH_3D=TRUE -WITH_SERVER=TRUE
+make
 make apidoc
 ```
 Then, in *doc/api/html/Info.plist* remove *CFBundleVersion* (key and string value), and add the following two lines
@@ -41,7 +42,16 @@ Then generate docset (doxytag2zealdb can be installed with pip)
 ```shell
 # First command fail on docsetutil missing, nevermind!
 cd doc/api/html && make
-doxytag2zealdb --tag doc/qgis.tag --db doc/api/html/QGIS.docset/Contents/Resources/docSet.dsidx  --include-parent-scopes --include-function-signatures
+cd ../../../
+doxytag2zealdb --tag doc/qgis.tag --db doc/api/html/QGIS_3.docset/Contents/Resources/docSet.dsidx  --include-parent-scopes --include-function-signatures
 ```
 
-Finally, add icons and meta.json
+Finally, add icons and docset.json to `doc/api/html/QGIS_3.docset`
+
+If you want to propose a PR to update this documentation, just zip it, share it (on Dropbox for instance) and give the URL in the PR.
+
+To create the tar archive
+
+```shell
+cd doc/api/html && tar cvzf QGIS.tgz doc/api/html/QGIS_3.docset
+```

--- a/docsets/QGIS/README.md
+++ b/docsets/QGIS/README.md
@@ -53,5 +53,5 @@ If you want to propose a PR to update this documentation, just zip it, share it 
 To create the tar archive
 
 ```shell
-cd doc/api/html && tar cvzf QGIS.tgz doc/api/html/QGIS_3.docset
+cd doc/api/html && tar cvzf QGIS.tgz --exclude='.DS_Store' doc/api/html/QGIS_3.docset
 ```

--- a/docsets/QGIS/docset.json
+++ b/docsets/QGIS/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "QGIS",
-    "version": "3.4.2",
+    "version": "3.16.1",
     "archive": "QGIS.tgz",
     "author": {
         "name": "Julien Cabieces",


### PR DESCRIPTION
Supersedes #3084 

This PR proposes to update the QGIS docset to new LTR stable version 3.16.

The docset is more than 600 MB, so I pushed it [here](https://www.dropbox.com/s/90660gn65bx3jox/QGIS.tgz?dl=0)