### PR TITLE
Update to ns-3.33

### DIFF
--- a/docsets/ns-3/Info.plist
+++ b/docsets/ns-3/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleIdentifier</key><string>org.nsnam.ns3</string>
 		<key>DocSetPlatformFamily</key><string>ns3</string>
 		<key>dashIndexFilePath</key><string>modules.html</string>
-		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.32/doxygen/index.html</string>
+		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.33/doxygen/index.html</string>
 		<key>isJavaScriptEnabled</key><true/>
 	</dict>
 </plist>

--- a/docsets/ns-3/docset.json
+++ b/docsets/ns-3/docset.json
@@ -1,6 +1,6 @@
 {
 	"name": "ns-3",
-	"version": "3.32",
+	"version": "3.33",
 	"archive": "ns-3.tgz",
 	"author": {
 		"name": "Elias Rohrer",
@@ -9,6 +9,10 @@
 	"aliases": [ "ns3" ],
 
 	"specific_versions": [
+		{ 
+			"version": "3.32",
+			"archive": "versions/3.32/ns-3.tgz"
+		},	
 		{ 
 			"version": "3.31",
 			"archive": "versions/3.31/ns-3.tgz"

--- a/docsets/ns-3/ns-3.tgz.txt
+++ b/docsets/ns-3/ns-3.tgz.txt
@@ -1,6 +1,0 @@
-Archive "ns-3.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-11-26 18:46:49 +0000
-SHA1: 56ed3e8abe869a70f6318749b21cdfaba078aa5c
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.


### PR DESCRIPTION
This PR updates the ns-3 docset to version 3.33.

As was the case with the last two updates, the docset size surpasses Github's 100MB limit. 
You can find it [via this Dropbox link](https://www.dropbox.com/s/szuktadtdysfpq2/ns-3.tgz?dl=0).

It would be great if you could place the old version under `versions/3.32/ns-3.tgz`.

Thank you!

