### PR TITLE
Update scikit-learn docset to 0.24.1 (closes #3173)

### DIFF
--- a/docsets/Scikit/build.sh
+++ b/docsets/Scikit/build.sh
@@ -41,7 +41,7 @@ git cherry-pick FETCH_HEAD  # patch sphinx to avoid overwriting generated files 
 ###git cherry-pick FETCH_HEAD  # n_jobs=1
 
 pip install -U pip
-pip install numpy scipy cython nose coverage matplotlib==2.* sphinx==2.1.2 pillow sphinx-gallery numpydoc scikit-image seaborn joblib pandas pytest
+pip install numpy scipy cython nose coverage matplotlib==2.* sphinx==2.1.2 pillow sphinx-gallery numpydoc scikit-image seaborn joblib pandas pytest sphinx-prompt
 pip install doc2dash scikit-learn==$tag
 NO_MATHJAX=1 make html optipng
 cd $workdir

--- a/docsets/Scikit/docset.json
+++ b/docsets/Scikit/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "scikit-learn",
-    "version": "0.23.1",
+    "version": "0.24.1",
     "archive": "scikit-learn.tgz",
     "author": {
         "name": "Aziz Alto, Josh Devlin, Christian Stade-Schuldt, Joel Nothman",


### PR DESCRIPTION
Closes #3173. 

- Adds updated docset tarball. 
- Adds missing `sphinx-prompt` package to `build.sh`.
- Updates `docset.json` file. 