### PR TITLE
Update Unreal Engine docset to 4.26

### DIFF
--- a/docsets/UnrealEngine4/docset.json
+++ b/docsets/UnrealEngine4/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Unreal Engine 4",
-    "version": "4.24",
+    "version": "4.26",
     "archive": "UnrealEngine4.tgz",
     "author": {
         "name": "Lorenz Junglas",


### PR DESCRIPTION
I Updated the UE4 docset to 4.26. I skipped version 4.25 (I can only scrap the current version form their website)

Since the compressed docset is about 3GB in size I have to upload it via google drive.
https://drive.google.com/file/d/15fnP4Ne2LFF6sHZr1nPGkZGf25h8lFIl/view?usp=sharing

Thanks for helping me fix the dark mode issues.
I also improved the category detection a lot and added an online fallback url.

Docset was generated with https://github.com/lolleko/unreal-docset