### PR TITLE
Update to ns-3.34

### DIFF
--- a/docsets/ns-3/Info.plist
+++ b/docsets/ns-3/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleIdentifier</key><string>org.nsnam.ns3</string>
 		<key>DocSetPlatformFamily</key><string>ns3</string>
 		<key>dashIndexFilePath</key><string>modules.html</string>
-		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.33/doxygen/index.html</string>
+		<key>DashDocSetFallbackURL</key><string>https://www.nsnam.org/docs/release/3.34/doxygen/index.html</string>
 		<key>isJavaScriptEnabled</key><true/>
 	</dict>
 </plist>

--- a/docsets/ns-3/docset.json
+++ b/docsets/ns-3/docset.json
@@ -1,6 +1,6 @@
 {
 	"name": "ns-3",
-	"version": "3.33",
+	"version": "3.34",
 	"archive": "ns-3.tgz",
 	"author": {
 		"name": "Elias Rohrer",
@@ -9,6 +9,10 @@
 	"aliases": [ "ns3" ],
 
 	"specific_versions": [
+		{ 
+			"version": "3.33",
+			"archive": "versions/3.33/ns-3.tgz"
+		},
 		{ 
 			"version": "3.32",
 			"archive": "versions/3.32/ns-3.tgz"


### PR DESCRIPTION
This updates the ns-3 docset to the latest version. As previously, this PR only includes the metadata, the actual docset can be found here: https://www.dropbox.com/s/z2ipcxx3v4sty41/ns-3.tgz?dl=0