### PR TITLE
fix(vega-lite): fix partial link to Vega Lite Category Overview page

### DIFF
--- a/docsets/Vega-Lite/docset.json
+++ b/docsets/Vega-Lite/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Vega-Lite",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "archive": "vega-lite.tgz",
     "author": {
         "name": "Cameron Yick",


### PR DESCRIPTION
## Motivation

Fixes https://github.com/hydrosquall/vega-lite-docset-generator/issues/4  by generating the HTML with `docs/index.html` instead of `docs/` as the sidebar entry.

The diff in the doc generator is here: https://github.com/vega/vega-lite/pull/7642/commits/1e68b99b1a7eab1261c0205cf1e77b7bcd0132b9

## Testing:

Tested locally, no longer 404s.