### PR TITLE
Requesting update of statsmodels docset to version 0.13.1

### DIFF
--- a/docsets/statsmodels/README.md
+++ b/docsets/statsmodels/README.md
@@ -10,27 +10,23 @@ Statsmodels Dash Docset
 - Docset Generation:
     - Read the `README.md` file in the `docs` directory. From the file:
       - _We use a combination of sphinx and Jupyter notebooks for the documentation. Jupyter notebooks should be used for longer, self-contained examples demonstrating a topic. Sphinx is nice because we get the tables of contents and API documentation._
-    - Clone the statsmodels GitHub repository and switch to the 0.12.0 tag.
-        - `git clone https://github.com/statsmodels/statsmodels.git`
-        - `git fetch --all --tags --prune`
-        - `git checkout tags/0.12.0 -b 0.12.0` (you may remove branch when done).
     - Create an environment for compiling the docs using Anaconda.
-      - `conda create -n statsmodels-docs -c conda-forge`
-    - Go into `cd statsmodels`.
+      - `conda create -n statsmodels-docs -c conda-docs`
+    - Clone from the statsmodels GitHub repository the v0.13.1 branch and switch to the directory.
+        - `git clone --branch=v0.13.1 https://github.com/statsmodels/statsmodels`
     - Run `python -m pip install -e .[docs]` to install Python packages contained in the `requirement.txt` files in the `docs/` folder.
-    - I needed to install several additional Python packages not contained in the `requirements.txt` file:
-        - `colorama`
-        - `theano`
+    - You may need to install several additional Python packages not contained in the `requirements.txt` file. Just run `python -m pip install <package-name>` or `conda install -c conda-forge <package-name>`. Some of the packages I needed to install include:
+        - `rpy2`
         - `pytest`
         - `seaborn`
-        - `arviz`
         - `pymc3`
-        - `PyYaml`
+        - `pyyaml`
         - `sphinx_material`
         - `nbsphinx`
+        - `graphviz`
     - Compile the docs with `make html`.
     - Install `doc2dash` with `python -m pip install doc2dash` (will also install: `zope.interface`, `soupsieve`, `beautifulsoup4`, `colorama`, `click`).
     - Go to `cd _build/html`.
-    - Run `doc2dash` command with option parameters. Mine was: 
-    ```doc2dash -n "statsmodels 0.12.0" -d "~/Library/ApplicationSupport/doc2dash/DocSets/statsmodels/0-12-0" -i "~/Pictures/Icons/dash/statsmodels/icon@2x.png" -v -j -u "https://www.statsmodels.org/" -I "index.html" ./ -a -f```
+    - Run `doc2dash` command with option parameters. My command was: 
+    ```doc2dash -n "statsmodels 0.13.1" -d "~/Library/ApplicationSupport/doc2dash/DocSets/statsmodels/0-13-1" -i "~/Pictures/Icons/dash/statsmodels/icon@2x.png" -v -j -u "https://www.statsmodels.org/" -I "index.html" ./ -a -f```
     - The statsmodels package will install directly into Dash.

--- a/docsets/statsmodels/docset.json
+++ b/docsets/statsmodels/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "statsmodels",
-    "version": "0.12.0",
+    "version": "0.13.1",
     "archive": "statsmodels.tgz",
     "author": {
         "name": "Angelo Varlotta",
@@ -9,10 +9,14 @@
     "aliases": [
         "Statsmodels",
         "statsmodels",
-        "Statsmodels 0.12.0",
-        "statsmodels 0.12.0"
+        "Statsmodels 0.13.1",
+        "statsmodels 0.13.1"
     ],
     "specific_versions": [
+        {
+            "version": "0.12.0",
+            "archive": "versions/0.12.0/statsmodels.tgz"
+        },
         {
             "version": "0.11.1",
             "archive": "versions/0.11.1/statsmodels.tgz"

--- a/docsets/statsmodels/statsmodels.tgz.txt
+++ b/docsets/statsmodels/statsmodels.tgz.txt
@@ -1,6 +1,0 @@
-Archive "statsmodels.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-09-12 13:10:53 +0000
-SHA1: 2064f9272c1c198ec3b2fe553f0f32b74c2b3017
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/statsmodels/versions/0.12.0/statsmodels.tgz.txt
+++ b/docsets/statsmodels/versions/0.12.0/statsmodels.tgz.txt
@@ -1,0 +1,6 @@
+Archive "statsmodels.tgz" was processed at this location, pushed to the CDN and completely removed from git.
+
+Date: 2020-09-12 13:10:53 +0000
+SHA1: 2064f9272c1c198ec3b2fe553f0f32b74c2b3017
+
+Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.


### PR DESCRIPTION
Update to Dash docset package for statsmodels 0.13.1, which includes 8 bug fixes for the 0.13 branch and brings initial support for Python 3.10.