### PR TITLE
New QGIS & PyQGIS 3.22 docset

### DIFF
--- a/docsets/PyQGIS/PyQGIS.tgz.txt
+++ b/docsets/PyQGIS/PyQGIS.tgz.txt
@@ -1,6 +1,6 @@
 Archive "PyQGIS.tgz" was processed at this location, pushed to the CDN and completely removed from git.
 
-Date: 2020-12-10 19:48:40 +0000
-SHA1: 1e500b9a22d5ba14b6978581b16233e00ed6e45a
+Date: 2021-12-23 15:17:50 +0000
+SHA1: 227700691a25ef81fb241e2266651617ca9c11f9
 
 Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/PyQGIS/README.md
+++ b/docsets/PyQGIS/README.md
@@ -3,7 +3,7 @@ QGIS
 
 ## Author
 
-This docset is maintained by [Julien Cabieces](https://github.com/troopa81)
+This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Antoine Facchini](https://github.com/Koyaani)
 
 ## Building
 
@@ -16,14 +16,13 @@ Build it
 ```shell
 mkdir build
 cd build
-cmake ../ -DWITH_3D=TRUE -WITH_SERVER=TRUE
-make
+cmake ../ -DWITH_3D=TRUE -DWITH_SERVER=TRUE
 ```
 
 Then, clone PyQGIS
 
 ```shell
-git clone https://github.com/qgis/pyqgis.git
+git clone https://github.com/qgis/pyqgis.git  --depth=1
 ```
 
 Copy `pyqgis.patch` in pyqgis directory and apply patch

--- a/docsets/PyQGIS/docset.json
+++ b/docsets/PyQGIS/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "PyQGIS",
-    "version": "3.16.1",
+    "version": "3.22.1",
     "archive": "PyQGIS.tgz",
     "author": {
-        "name": "Julien Cabieces",
-        "link": "https://github.com/troopa81"
+        "name": "Antoine Facchini",
+        "link": "https://github.com/Koyaani"
     },
     "aliases": ["PyQGIS", 
                 "PyQGIS 3"],

--- a/docsets/QGIS/QGIS.tgz.txt
+++ b/docsets/QGIS/QGIS.tgz.txt
@@ -1,6 +1,6 @@
 Archive "QGIS.tgz" was processed at this location, pushed to the CDN and completely removed from git.
 
-Date: 2020-12-17 19:49:45 +0000
-SHA1: e30f1fcf96457bf693439459ec9c24de24e82ed7
+Date: 2021-12-23 15:17:43 +0000
+SHA1: ed6b78d2966a2d4c8805b36aadb2cfa3022f61fc
 
 Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/QGIS/README.md
+++ b/docsets/QGIS/README.md
@@ -3,7 +3,7 @@ QGIS
 
 ## Author
 
-This docset is maintained by [Julien Cabieces](https://github.com/troopa81)
+This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Antoine Facchini](https://github.com/Koyaani)
 
 ## Building
 
@@ -15,6 +15,7 @@ git clone https://github.com/qgis/QGIS.git
 Then edit Doxyfile template file *cmake_templates/Doxyfile.in* and modify these values
 ```
 GENERATE_DOCSET        = YES
+PROJECT_NAME           = "QGIS"
 DOCSET_FEEDNAME        = "QGIS"
 DOCSET_BUNDLE_ID       = QGIS_3
 DOCSET_PUBLISHER_ID    = com.QGIS
@@ -23,13 +24,13 @@ DISABLE_INDEX          = YES
 SEARCHENGINE           = NO
 GENERATE_TAGFILE       = qgis.tag
 ```
+`STRIP_FROM_PATH` could be set to remove the user-defined part of the path.
 
 Build it
 ```shell
 mkdir build
 cd build
-cmake ../ -DWITH_APIDOC=TRUE -DWITH_3D=TRUE -WITH_SERVER=TRUE
-make
+cmake ../ -DWITH_APIDOC=TRUE -DWITH_3D=TRUE -DWITH_SERVER=TRUE
 make apidoc
 ```
 Then, in *doc/api/html/Info.plist* remove *CFBundleVersion* (key and string value), and add the following two lines

--- a/docsets/QGIS/docset.json
+++ b/docsets/QGIS/docset.json
@@ -1,11 +1,11 @@
 {
     "name": "QGIS",
-    "version": "3.16.1",
+    "version": "3.22.1",
     "archive": "QGIS.tgz",
     "author": {
-        "name": "Julien Cabieces",
-        "link": "https://github.com/troopa81"
+        "name": "Antoine Facchini",
+        "link": "https://github.com/Koyaani"
     },
-    "aliases": ["QGIS", 
+    "aliases": ["QGIS",
                 "QGIS 3"],
 }


### PR DESCRIPTION
Supersedes #3098 made by @troopa81.

This PR update the QGIS and PyQGIS documentations to the version 3.22.1. There are also few improvements made in the 2 README.md.

Because of the size, the documentations can be downloaded here : [QGIS](https://we.tl/t-FbU7VzxzHP) and [PyQGIS](https://we.tl/t-GFXh2cM1nu). 