### PR TITLE
Revert author update

### DIFF
--- a/docsets/WP-CLI/README.md
+++ b/docsets/WP-CLI/README.md
@@ -2,7 +2,7 @@
 
 ## Author
 
-[Ross Wintle](https://github.com/rosswintle)
+[Patrik Csak](https://github.com/ptrkcsk)
 
 ## How to generate this docset
 

--- a/docsets/WP-CLI/docset.json
+++ b/docsets/WP-CLI/docset.json
@@ -3,8 +3,8 @@
     "version": "2.6.0",
     "archive": "WP-CLI.tgz",
     "author": {
-        "name": "Ross Wintle",
-        "link": "https://github.com/rosswintle"
+        "name": "Patrik Csak",
+        "link": "https://github.com/ptrkcsk"
     },
     "aliases": [
         "wordpress",


### PR DESCRIPTION
@rosswintle Thanks for adding the latest versions of the WP-CLI docsets to this repo

This PR reverts the author from @rosswintle back to myself, as I authored the project which generates the WP-CLI docsets: https://github.com/wp-cli/dash-docset-generator

@Kapeli It feels like a safe assumption that `author` should refer to the author who contributed the work of generating the docset, as opposed to the person who executed the generator last, but let me know if I've misunderstood