### PR TITLE
update godot docset to the latest stable (3.4.4)

### DIFF
--- a/docsets/Godot/README.md
+++ b/docsets/Godot/README.md
@@ -3,52 +3,17 @@ Godot Docset
 
 [Godot](https://godotengine.org/) docset for [Dash](http://kapeli.com/dash).
 
-By [Dmitrii Maganov](https://github.com/vonagam).
+Generated and optimized by [poga](https://github.com/poga)
 
-Instructions how to reproduce the build (using version 3.2 as an example):
+## Build
 
-- Install [Dashing](https://github.com/technosophos/dashing) (`brew install dashing` on mac).
+The docset is generated with a custom script to optimize reading experience in dash.
 
-- Download documentation sources from https://github.com/godotengine/godot-docs/tree/3.2
+Highlights:
 
-- Build documentation with `pip install -r requirements.txt` and `make html`.
+- full support of ToC
+- sidebar removed
+- simple custom script that can be easily modified for future doc updates
 
-- Move into built documentation folder (`_build/html`).
+Checkout the [repo](https://github.com/poga/godot-dash-docset) for more detail.
 
-- Optionally copy provided here `icon@2x.png`.
-
-- Create `dashing.json`:
-
-```json
-{
-  "name": "Godot",
-  "package": "godot",
-  "index":"index.html",
-  "icon32x32": "icon@2x.png",
-  "allowJS": true,
-  "ExternalURL": "https://docs.godotengine.org/en/3.2",
-  "selectors": {
-    "span[id^=doc-] + h1": {
-      "type": "Guide",
-      "regexp": "¶$",
-      "replacement": ""
-    },
-    "span[id^=class-] + h1": {
-      "type": "Class",
-      "regexp": "¶$",
-      "replacement": ""
-    },
-    ".section#signals > ul[id^=class-] > li > strong:first-of-type": "Event",
-    ".section#enumerations > p[id^=class-] > strong:first-of-type": "Enum",
-    ".section#enumerations > p[id^=class-] + ul > li > strong:first-of-type": "Value",
-    ".section#constants > ul[id^=class-] > li > strong:first-of-type": "Constant",
-    ".section#method-descriptions > ul[id^=class-] > li > strong:first-of-type": "Method",
-    ".section#property-descriptions > ul[id^=class-] > li > strong:first-of-type": "Property"
-  },
-  "ignore": [
-    "@C#¶"
-  ]
-}
-```
-
-- Run `dashing build` to create docset.

--- a/docsets/Godot/docset.json
+++ b/docsets/Godot/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "Godot",
-    "version": "3.2",
+    "version": "3.4.4",
     "archive": "godot.tgz",
     "author": {
-        "name": "Dmitrii Maganov",
-        "link": "https://github.com/vonagam"
+        "name": "Poga Po",
+        "link": "https://github.com/poga"
     },
     "aliases": []
 }

--- a/docsets/Godot/godot.tgz.txt
+++ b/docsets/Godot/godot.tgz.txt
@@ -1,6 +1,0 @@
-Archive "godot.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-05-05 11:43:33 +0000
-SHA1: ccd1d904e108041dfb90b67d6229d040d59eb20c
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.


### PR DESCRIPTION
The actual [`godot.tgz`] can be downloaded from [google drive](https://drive.google.com/file/d/10L5PqqMMvD5rtlfHDbfCRIFDPpF8gqJ9/view?usp=sharing) since it's larger than 100MB(186MB).

The docset is generated and optimized with [a custom script](https://github.com/poga/godot-dash-docset).

Please let me know if there's any issue when downloading :)

## checklist

- [x] You must maintain your docset! Always update it to the latest stable version as soon as possible
- [x] You must try to fix any issues/bugs that might be reported

- [x] The docset name must match the official API name (e.g., if you make a docset for PostgreSQL, don't call it psql)
- [x] The docset must not include a version in its Info.plist or in the docset filename
- [x] All pages must work offline (online resources are okay only if there's absolutely no way to avoid them)
- [x] The docset index must not contain entries with new lines in them or empty entries or broken paths
- [x] The docset must be for public use (i.e. don't contribute a docset that only you or your team will use)

- [x] Docset should have an icon
- [x] Docset should have an [index page set](http://kapeli.com/docsets#settingindexpage)
- [x] Docset should have [JavaScript enabled](http://kapeli.com/docsets#enableJavascript) if it needs it
- [x] Docset should have [table of contents support](http://kapeli.com/dash_guide#tableOfContents) if it makes sense
- [x] Docset should be optimised for display in Dash

