### PR TITLE
fix godot docset linking to imprecise anchor positions

### DIFF
--- a/docsets/Godot/docset.json
+++ b/docsets/Godot/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Godot",
-    "version": "3.4.4",
+    "version": "3.4.4/01",
     "archive": "godot.tgz",
     "author": {
         "name": "Poga Po",


### PR DESCRIPTION
This is a bugfix update for godot docset `3.4.4`. The docset `godot.tgz` need to be downloaded from [google drive](https://drive.google.com/file/d/10L5PqqMMvD5rtlfHDbfCRIFDPpF8gqJ9/view?usp=sharing)

## Changelog

- Fix search result anchors linking to imprecise positions.