### PR TITLE
Update docset JSON_for_Modern_C++ to v3.11.2

### DIFF
--- a/docsets/JSON_for_Modern_C++/JSON_for_Modern_C++.tgz.txt
+++ b/docsets/JSON_for_Modern_C++/JSON_for_Modern_C++.tgz.txt
@@ -1,6 +1,0 @@
-Archive "JSON_for_Modern_C++.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2022-01-06 20:19:30 +0000
-SHA1: ecf8acd192f491e35e2da0d294077daba394d9b1
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/JSON_for_Modern_C++/docset.json
+++ b/docsets/JSON_for_Modern_C++/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "JSON for Modern C++",
-  "version": "3.10.5",
+  "version": "3.11.2",
   "archive": "JSON_for_Modern_C++.tgz",
   "author": {
     "name": "Niels Lohmann",


### PR DESCRIPTION
https://github.com/nlohmann/json/releases/tag/v3.11.2 was just released.

Docset documentation was improved and the generated docset should now be on par with the mkdocs documentation (i.e., no missing pages).