### PR TITLE
Update wagtail's main version

### DIFF
--- a/docsets/Wagtail/docset.json
+++ b/docsets/Wagtail/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "Wagtail",
-  "version": "2.8.1",
+  "version": "4.0",
   "archive": "Wagtail.tgz",
   "author": {
     "name": "lb-",


### PR DESCRIPTION
This pull request updates wagtail's main version in the `docset.json` file to `version 4.0`