### PR TITLE
Update PEPs docset and build with Sphinx and local links

### DIFF
--- a/docsets/PEPs/PEPs.tgz.txt
+++ b/docsets/PEPs/PEPs.tgz.txt
@@ -1,6 +1,0 @@
-Archive "PEPs.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2020-07-31 21:15:23 +0000
-SHA1: 78100314583aa6cfd7ca2c2e5ae2ddf8a2c86dee
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/PEPs/README.md
+++ b/docsets/PEPs/README.md
@@ -1,8 +1,23 @@
-PEPs Docset
-=======================
+# PEPs Docset
 
 This docset contains all PEPs from the Python Software Foundation.
 
-Author: [QuantumGhost](https://github.com/quantumghost)
+## Building the docset
 
-Generating Instructions: [pepdash](https://github.com/quantumghost/pepdash)
+1. Clone the [PEPs repository](https://github.com/python/peps)
+2. Follow the build instructions. As of 2023.01.28, you need to 
+   `pip install -r requirements.txt` and `make render`.
+3. Install [`doc2dash`](https://pypi.org/project/doc2dash/).
+4. Build Docset from built HTML:
+
+```bash
+doc2dash --index-page index.html --icon build/_static/py.png --online-redirect-url https://peps.python.org/ build
+```
+
+## Hiccups
+
+The [`:pep:` Sphinx role typically generates a hyperlink to the PEPs website](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-pep), 
+but when buliding the PEPs documentation locally we'd like it to link to relative
+pages. Indeed, the PEP repository overrides this role to provide this behaviour,
+but until [PR #2972](https://github.com/python/peps/pull/2972) it was linking to
+an absolute path which broke internal links when browsing locally.

--- a/docsets/PEPs/docset.json
+++ b/docsets/PEPs/docset.json
@@ -1,11 +1,13 @@
 {
     "name": "Python Enhancement Proposals",
-    "version": "2020.07",
+    "version": "2023.01.28",
     "archive": "PEPs.tgz",
     "author": {
-        "name": "QuantumGhost",
-        "link": "https://github.com/quantumghost"
+        "name": "Warren Alphonso",
+        "link": "https://github.com/warrenalphonso"
     },
-    "aliases": ["PEP",
-                "PEPs"],
+    "aliases": [
+        "PEP",
+        "PEPs"
+    ]
 }


### PR DESCRIPTION
The current PEP docset is scraped from the [Python PEPs website](https://peps.python.org/). I've built the documentation with Sphinx and converted it with `doc2dash` to generate this Docset. 