### PR TITLE
Update boto3 to 1.26.121

### DIFF
--- a/docsets/Boto3/Makefile
+++ b/docsets/Boto3/Makefile
@@ -8,8 +8,9 @@ DOCSET ?= $(shell pwd)
 
 fetch:
 	cd $(BOTO3_SRC) && \
-		git fetch && \
-		git checkout $(shell cd $(BOTO3_SRC) && git tag | sort -V | tail -n1 )
+		git fetch
+	cd $(BOTO3_SRC) && \
+		git checkout "$$(cd $(BOTO3_SRC) && git tag | sort -V | tail -n1 )"
 
 docs:
 	cd $(BOTO3_SRC) && \

--- a/docsets/Boto3/README.md
+++ b/docsets/Boto3/README.md
@@ -3,7 +3,7 @@ Boto3 Docset
 Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for Python, which allows Python developers to write software that makes use of services like Amazon S3 and Amazon EC2.
 http://boto3.readthedocs.io/en/latest/
 
-* Boto3 Version: 1.26.96
+* Boto3 Version: 1.26.121
 * Dash Docset: Updated by James Seward
 * Twitter: @jamesoff
 * Mastodon: @jamesoff@mastodon.jamesoff.net

--- a/docsets/Boto3/boto3.tgz.txt
+++ b/docsets/Boto3/boto3.tgz.txt
@@ -1,6 +1,0 @@
-Archive "boto3.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2023-03-28 10:12:00 +0000
-SHA1: f204d53378748bfa177eab80c8090866816b7ed3
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/Boto3/docset.json
+++ b/docsets/Boto3/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "boto3",
-  "version": "1.26.96",
+  "version": "1.26.121",
   "archive": "boto3.tgz",
   "author": {
     "name": "James Seward",


### PR DESCRIPTION
As before, the tgz file is now too big to push directly to github.

The file is available to download from https://d24v0t7zqzj9pw.cloudfront.net/1.26.121/boto3.tgz - this link will function for 90d.

Thanks!