### PR TITLE
Update QGIS docset to 3.30

### DIFF
--- a/docsets/QGIS/docset.json
+++ b/docsets/QGIS/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "QGIS",
-    "version": "3.22.1",
+    "version": "3.30.3",
     "archive": "QGIS.tgz",
     "author": {
-        "name": "Antoine Facchini",
-        "link": "https://github.com/Koyaani"
+        "name": "Jacky Volpes",
+        "link": "https://github.com/Djedouas"
     },
     "aliases": ["QGIS",
                 "QGIS 3"],


### PR DESCRIPTION
This is the follow-up of #3540 made by @Koyaani and @troopa81 

Updating QGIS documentation to 3.30.3

Because of the size, the documentations can be [downloaded here](https://send.volpes.fr/download/eb51f581609267fa/#GP7pEIXimX7cYFuIAxS4WQ)