### PR TITLE
feat: update vega-lite docset for Vega-Lite 5.16.3

### DIFF
--- a/docsets/Vega-Lite/README.md
+++ b/docsets/Vega-Lite/README.md
@@ -2,6 +2,8 @@
 # Vega-Lite Docset
 
 * Maintainer: Cameron Yick ([Github][github]/[Twitter][twitter])
+* Offline version of https://vega.github.io/vega-lite/docs/
+* Version: [5.16.3](https://github.com/vega/vega-lite/releases/tag/v5.16.3)
 
 ## Instructions
 

--- a/docsets/Vega-Lite/docset.json
+++ b/docsets/Vega-Lite/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Vega-Lite",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "archive": "vega-lite.tgz",
     "author": {
         "name": "Cameron Yick",


### PR DESCRIPTION
## Motivation

- Vega-Lite is an open source graphing library used in Python, JavaScript, etc
- Update docs originally contributed in https://github.com/Kapeli/Dash-User-Contributions/pull/3383

## Changes

- Updates contents by rerunning my [generator script](https://github.com/hydrosquall/vega-lite-docset-generator/blob/main/README.md#features)
  - From `5.1.0` released [Apr 16 2021](https://github.com/vega/vega-lite/commit/64739639fd85d9be605704c91425d26450d25b9c) )  to 
  - to latest `5.16.3` released [Nov 9 2023](https://github.com/vega/vega-lite/releases/tag/v5.16.3) . ( Required making updates to the site's build script for a [clean output](https://github.com/vega/vega-lite/pull/9254) ) 
