### PR TITLE
feat: update vega docset for Vega 5.27.0

### DIFF
--- a/docsets/Vega/README.md
+++ b/docsets/Vega/README.md
@@ -1,6 +1,9 @@
 # Vega Docset
 
 * Maintainer: Cameron Yick ([Github][github]/[Twitter][twitter])
+* Offline version of <https://vega.github.io/vega/docs/>
+* Version: [5.27.0](https://github.com/vega/vega/releases/tag/v5.27.0)
+
 
 ## Instructions
 

--- a/docsets/Vega/docset.json
+++ b/docsets/Vega/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "Vega",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "archive": "vega.tgz",
   "author": {
     "name": "Cameron Yick",


### PR DESCRIPTION
## Motivation 

- Update documentation for Vega open-source graphing library
- Update https://github.com/Kapeli/Dash-User-Contributions/pull/3398

## Changes

- Updates contents by rerunning my [generator script](https://github.com/hydrosquall/vega-docset-generator/blob/main/README.md#features)
  - From `5.20.2` released [Mar 30 2021](https://github.com/vega/vega/releases/tag/v5.20.2) )  to 
  - to latest `5.27.0` released [Jan 3 2024](https://github.com/vega/vega/releases/tag/v5.27.0) . ( Required updating to the site's build script for a [clean output](https://github.com/vega/vega/pull/3280) ) 