### PR TITLE
Update QGIS to 3.36.1

### DIFF
--- a/docsets/QGIS/docset.json
+++ b/docsets/QGIS/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "QGIS",
-    "version": "3.30.3",
+    "version": "3.36.1",
     "archive": "QGIS.tgz",
     "author": {
         "name": "Jacky Volpes",


### PR DESCRIPTION
Updating QGIS docset to version 3.36.1.

[Download link (expire in 30 days) for the docset](https://plik.vulpecula.fr/file/D7l2YxoCPR8gHgfo/vedLMab3cczdggdi/QGIS.tgz?dl=1).

Thanks 🙂 