### PR TITLE
Update PyQGIS to 3.36.1

### DIFF
--- a/docsets/PyQGIS/docset.json
+++ b/docsets/PyQGIS/docset.json
@@ -1,10 +1,10 @@
 {
     "name": "PyQGIS",
-    "version": "3.22.1",
+    "version": "3.36.1",
     "archive": "PyQGIS.tgz",
     "author": {
-        "name": "Antoine Facchini",
-        "link": "https://github.com/Koyaani"
+        "name": "Jacky Volpes",
+        "link": "https://github.com/Djedouas"
     },
     "aliases": ["PyQGIS", 
                 "PyQGIS 3"],


### PR DESCRIPTION
Updating PyQGIS docset to version 3.36.1.

[Download link (expire in 30 days) for the docset](https://plik.vulpecula.fr/file/wYsy7veGTWLjp8F2/mrFpWfLZETsoLmEe/PyQGIS.tgz?dl=1).