### PR TITLE
Update ACL2 docset to v8.5

### DIFF
--- a/docsets/ACL2/docset.json
+++ b/docsets/ACL2/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "ACL2",
-    "version": "8.4.3",
+    "version": "8.5.0",
     "archive": "ACL2.tgz",
     "author": {
         "name": "Mu Xian Ming",


### PR DESCRIPTION
Update docs to the latest version:
https://www.cs.utexas.edu/users/moore/acl2/v8-5/combined-manual/index.html\

BTW, can I qualify for a free license of the latest version please? The repo below contains the scripts I've written to generate this docset:
https://github.com/marsmxm/acl2dash

And my email address is marsmxm@gmail.com. Thanks!