### PR TITLE
Update QGIS and PyQGIS to 3.38.1

### DIFF
--- a/docsets/PyQGIS/README.md
+++ b/docsets/PyQGIS/README.md
@@ -1,9 +1,9 @@
-QGIS
+PyQGIS
 =======================
 
 ## Author
 
-This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Antoine Facchini](https://github.com/Koyaani)
+This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Jacky Volpes](https://github.com/Djedouas)
 
 ## Building
 
@@ -17,6 +17,7 @@ Build it
 mkdir build
 cd build
 cmake ../ -DWITH_3D=TRUE -DWITH_SERVER=TRUE
+make
 ```
 
 Then, clone PyQGIS

--- a/docsets/PyQGIS/docset.json
+++ b/docsets/PyQGIS/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "PyQGIS",
-    "version": "3.36.1",
+    "version": "3.38.1",
     "archive": "PyQGIS.tgz",
     "author": {
         "name": "Jacky Volpes",

--- a/docsets/PyQGIS/pyqgis.patch
+++ b/docsets/PyQGIS/pyqgis.patch
@@ -1,31 +1,30 @@
-diff --git a/conf.py.in b/conf.py.in
-index 486f489..3239f58 100644
---- a/conf.py.in
-+++ b/conf.py.in
-@@ -3,8 +3,6 @@
- import sys, os
- import yaml
+diff --git a/conf.in.py b/conf.in.py
+index 6515474..b550ab5 100644
+--- a/conf.in.py
++++ b/conf.in.py
+@@ -1,7 +1,6 @@
+ import os
+ import sys
  
 -import sphinx_rtd_theme
--
+ import yaml
  
  # If extensions (or modules to document with autodoc) are in another directory,
- # add these directories to sys.path here. If the directory is relative to the
-@@ -65,8 +63,7 @@ pygments_style = 'sphinx'
+@@ -73,8 +72,7 @@ pygments_style = "sphinx"
  
  # The theme to use for HTML and HTML Help pages.  See the documentation for
  # a list of builtin themes.
--html_theme = 'sphinx_rtd_theme'
+-html_theme = "sphinx_rtd_theme"
 -html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]  # use with module import
 +html_theme = 'python_docs_theme'
  
  # html_theme_path = ['.']  # use with git submodule
  
-@@ -81,6 +78,7 @@ html_theme_options = {
-   'titles_only': True,
-   'versioning': True,
-   'canonical_url': 'https://qgis.org/pyqgis/latest',
-+  'nosidebar': True
+@@ -89,6 +87,7 @@ html_theme_options = {
+     "titles_only": True,
+     "versioning": True,
+     "canonical_url": "https://qgis.org/pyqgis/latest",
++    "nosidebar": True
  }
  
  # Add any paths that contain custom themes here, relative to this directory.

--- a/docsets/QGIS/README.md
+++ b/docsets/QGIS/README.md
@@ -3,7 +3,7 @@ QGIS
 
 ## Author
 
-This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Antoine Facchini](https://github.com/Koyaani)
+This docset is maintained by [Julien Cabieces](https://github.com/troopa81) and [Jacky Volpes](https://github.com/Djedouas)
 
 ## Building
 

--- a/docsets/QGIS/docset.json
+++ b/docsets/QGIS/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "QGIS",
-    "version": "3.36.1",
+    "version": "3.38.1",
     "archive": "QGIS.tgz",
     "author": {
         "name": "Jacky Volpes",


### PR DESCRIPTION
Updating QGIS and PyQGIS docsets to version 3.38.1

Here are the links for the 2 docsets:

[QGIS docset](https://transfert.facil.services/r/9JXJ_6T6Gk#k9gUH/jSSrqUeHExTXnIMe5DUtt+0ETU0z9U9D0fKIk=)

[PyQGIS docset](https://github.com/user-attachments/files/16498579/PyQGIS_3.docset.zip)

Thanks 😉 