### PR TITLE
update Blender to 4.2

### DIFF
--- a/docsets/Blender/docset.json
+++ b/docsets/Blender/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "Blender",
-    "version": "3.6",
+    "version": "4.2",
     "archive": "Blender.tgz",
     "author": {
         "name": "Yue Gao",
@@ -8,6 +8,10 @@
     },
     "aliases": ["Blender"],
     "specific_versions": [
+        {
+            "version": "4.2",
+            "archive": "versions/4.2/Blender.tgz"
+        },
         {
             "version": "3.6",
             "archive": "versions/3.6/Blender.tgz"


### PR DESCRIPTION
Update Blender to latest LTS 4.2
The Blender.tgz is too large to push to Github, and is located in: https://www.dropbox.com/s/7mtqcgvznuy3lsw/Blender.tgz?dl=0