### PR TITLE
Bump boto3 to 1.35.49

### DIFF
--- a/docsets/Boto3/README.md
+++ b/docsets/Boto3/README.md
@@ -3,7 +3,7 @@ Boto3 Docset
 Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for Python, which allows Python developers to write software that makes use of services like Amazon S3 and Amazon EC2.
 http://boto3.readthedocs.io/en/latest/
 
-* Boto3 Version: 1.35.13
+* Boto3 Version: 1.35.49
 * Dash Docset: Updated by James Seward
 * Twitter: @jamesoff
 * Mastodon: @jamesoff@mastodon.jamesoff.net

--- a/docsets/Boto3/boto3.tgz.txt
+++ b/docsets/Boto3/boto3.tgz.txt
@@ -1,6 +1,0 @@
-Archive "boto3.tgz" was processed at this location, pushed to the CDN and completely removed from git.
-
-Date: 2024-09-11 08:07:47 +0000
-SHA1: 94e281e2e85f936f1da15d283bf3dc36e3604040
-
-Note: This file is just a txt file, nothing more. It does not act as a placeholder for the original archive. Deleting, moving or renaming this file does nothing.

--- a/docsets/Boto3/docset.json
+++ b/docsets/Boto3/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "boto3",
-  "version": "1.35.13",
+  "version": "1.35.49",
   "archive": "boto3.tgz",
   "author": {
     "name": "James Seward",


### PR DESCRIPTION
Binary available at https://d24v0t7zqzj9pw.cloudfront.net/1.35.49/boto3.tgz for 90d.

Thanks!