### PR TITLE
Update Xarray to 2025.06.1

### DIFF
--- a/docsets/xarray/README.md
+++ b/docsets/xarray/README.md
@@ -6,32 +6,54 @@
 
 - Florian Knoop ([Twitter](https://twitter.com/floknoo) · [GitHub](https://github.com/flokno))
 - Xavier Yang ([GitHub](https://github.com/ivaquero))
+- Clément Haëck ([GitHub](https://github.com/Descanonge)): Update to 2026.6
 
 ## Instructions
 
 - download the latest document from https://github.com/pydata/xarray
 - unpack the zip file
 - `cd xarray-main/doc`
-- comment `intersphinx_mapping` block
-- custom options in `sphinx` `conf.py` in order to remove sidebar
-
+- custom sphinx options in `doc/conf.py` in order to remove sidebar and navbar:
 ```python
-html_theme = 'alabaster'
+html_sidebars = {"**": []}
+html_theme_options = {
+    "navbar_start": [],
+    "navbar_center": [],
+    "navbar_end": [],
+    "navbar_persistent": [],
+}
+```
 
-html_theme_options = dict(
-    logo_only=True,
-    nosidebar=True,
+- you may have to specify extra arguments to jupyter_sphinx to run correctly locally:
+``` python
+jupyter_execute_kwargs = dict(
+    timeout=-1, allow_errors=True, extra_arguments=["--matplotlib=inline"]
 )
 ```
 
-- run the following commands
+- Make available a [custom parser](./parser.py) which will filters duplicate entries:
+``` bash
+cp parser.py xarray-main/xarray
+```
 
+- build the documentation:
 ```bash
 make html
-doc2dash -v -n xarray -i xarray-main/doc/_build/html/_static/dataset-diagram-square-logo -I xarray-main/doc/_build/html/index.html xarray-main/doc/_build/html
-tar cvzf xarray.tgz xarray.docset
+doc2dash -v -n xarray -I index.html -u "https://docs.xarray.dev/en/stable/" \
+    --parser xarray.parser.InterSphinxFilter \
+    xarray-main/doc/_build/html 
+```
+
+- copy icons:
+``` bash
+cp icons*.png xarray.docset
+```
+
+- Create archive:
+```bash
+tar --exclude=".DS_STORE' -cvzf xarray.tgz xarray.docset
 ```
 
 ## More details
 
-Details on how to build the `xarray` documentation can be found [here](http://xarray.pydata.org/en/stable/contributing.html#how-to-build-the-xarray-documentation).
+Details on how to build the `xarray` documentation can be found [here](https://docs.xarray.dev/en/stable/contribute/contributing.html#how-to-build-the-xarray-documentation).

--- a/docsets/xarray/docset.json
+++ b/docsets/xarray/docset.json
@@ -1,19 +1,13 @@
 {
     "name": "xarray",
-    "version": "2023.09.0",
+    "version": "2025.06.1",
     "archive": "xarray.tgz",
     "author": {
-        "name": "Florian Knoop, Xavier Yang",
-        "link": "https://github.com/flokno, https://github.com/ivaquero"
+        "name": "Florian Knoop, Xavier Yang, Clément Haëck",
+        "link": "https://github.com/flokno, https://github.com/ivaquero, https://github.com/Descanonge"
     },
     "aliases": [
         "Python",
         "N-D labeled arrays and datasets in Python"
-    ],
-    "specific_versions": [
-        {
-            "version": "2023.09.0",
-            "archive": "versions/2023.09.0/xarray.tgz"
-        }
     ]
 }

--- a/docsets/xarray/docset.json
+++ b/docsets/xarray/docset.json
@@ -9,5 +9,15 @@
     "aliases": [
         "Python",
         "N-D labeled arrays and datasets in Python"
+    ],
+    "specific_versions": [
+        {
+            "version": "2025.06.1",
+            "archive": "versions/2025.06.1/xarray.tgz"
+        },
+        {
+            "version": "2023.09.0",
+            "archive": "versions/2023.09.0/xarray.tgz"
+        }
     ]
 }

--- a/docsets/xarray/parser.py
+++ b/docsets/xarray/parser.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import logging
+from collections.abc import Generator, Mapping
+
+from doc2dash.parsers.intersphinx import InterSphinxParser
+from doc2dash.parsers.intersphinx_inventory import InventoryEntry
+from doc2dash.parsers.types import ParserEntry
+
+log = logging.getLogger(__name__)
+
+
+class InterSphinxFilter(InterSphinxParser):
+    def _inv_to_entries(
+        self, inv: Mapping[str, Mapping[str, InventoryEntry]]
+    ) -> Generator[ParserEntry, None, None]:
+        inv = dict(inv)
+
+        # Filter out labels that point to objects
+        obj_types = [typ for typ in inv.keys() if typ.startswith("py:")]
+
+        remove = []
+        for type_key in obj_types:
+            for key in inv[type_key]:
+                for ignore_type in ["std:doc", "std:label"]:
+                    for ignore_key, (_, name) in inv[ignore_type].items():
+                        if (
+                            ignore_key.endswith(key)
+                            or ignore_key.endswith(key.lower())
+                            or ignore_key.endswith(key.replace(".", "-").lower())
+                            or ignore_key.endswith(key + ".rst")
+                            or ignore_key.endswith(key.lower() + ".rst")
+                            or ignore_key == name
+                        ):
+                            remove.append((ignore_type, ignore_key))
+
+        # Filter out labels that point to the title section
+        type_key = "std:label"
+        for key, (_, name) in inv[type_key].items():
+            if key.find(".rst#") > 0 and key.endswith(
+                "#" + name.lower().replace(" ", "-").replace(".", "-")
+            ):
+                remove.append((type_key, key))
+
+        # Filter out whats new labels (except versions sections)
+        type_key = "std:label"
+        for key in inv[type_key]:
+            if key.startswith("/waths-new.rst#") and not key.startswith(
+                "/whats-new.rst#v"
+            ):
+                remove.append((type_key, key))
+
+        for typ, key in remove:
+            inv[typ].pop(key, None)
+
+        yield from super()._inv_to_entries(inv)


### PR DESCRIPTION
Xarray docset was quite out of date, I took the liberty of updating it. I can continue to maintain it.

I included a custom doc2dash parser that filters out the (thousands of) duplicate entries, since every document and object has one or more "std:label"/section pointing to the same place.