### PR TITLE
Update RFCs docset

### DIFF
--- a/docsets/RFCs/docset.json
+++ b/docsets/RFCs/docset.json
@@ -1,6 +1,6 @@
 {
   "name": "RFCs",
-  "version": "2024.09.19/1.0.0",
+  "version": "2025.09.13/1.1.0",
   "archive": "RFCs.tgz",
   "author": {
     "name": "Alexander Mankuta",


### PR DESCRIPTION
The docset file: [RFCs.tgz](https://files.pointless.one/RFCs-docset/2025.09.13-1.1.0/RFCs.tgz).

This add new RFCs published since the last docset release.