### PR TITLE
Update TLDR pages docset to 2026-06-01

### DIFF
--- a/docsets/tldr/docset.json
+++ b/docsets/tldr/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "tldr pages",
-    "version": "2026-05-01",
+    "version": "2026-06-01",
     "archive": "tldr_pages.tgz",
     "author": {
         "name": "cvn",


### PR DESCRIPTION
This is an automated update created by [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml).